### PR TITLE
Add Hugging Face integration

### DIFF
--- a/efficient_sam/build_efficient_sam.py
+++ b/efficient_sam/build_efficient_sam.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .efficient_sam import build_efficient_sam
+from efficient_sam import build_efficient_sam
 
 def build_efficient_sam_vitt():
     return build_efficient_sam(

--- a/efficient_sam/efficient_sam_decoder.py
+++ b/efficient_sam/efficient_sam_decoder.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .mlp import MLPBlock
+from mlp import MLPBlock
 
 
 class PromptEncoder(nn.Module):

--- a/efficient_sam/two_way_transformer.py
+++ b/efficient_sam/two_way_transformer.py
@@ -2,7 +2,7 @@ import math
 from typing import Tuple, Type
 import torch
 from torch import nn, Tensor
-from .mlp import MLPBlock
+from mlp import MLPBlock
 
 
 


### PR DESCRIPTION
Hi @yformer and team!

Thanks for this nice work. I wrote a quick PoC to showcase that you can easily have integration so that you can automatically load the various EfficientSAM models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from efficient_sam import EfficientSAM

model = EfficientSAM.from_pretrained("nielsr/efficientsam-tiny")
```
The corresponding model is here for now: https://huggingface.co/nielsr/efficientsam-tiny. We could move all checkpoints to separate repos on your account on https://hf.co if you're interested.

This will make sure you can track download numbers for each individual checkpoint!

Would you be interested in this integration?

Kind regards,

Niels